### PR TITLE
2-frame JJ window and add reset command

### DIFF
--- a/JackJack.lua
+++ b/JackJack.lua
@@ -252,12 +252,12 @@ local function setUpFrame()
     local titleFrame, searchBox = addon.setUpTitleFrame()
     
     local contentFrame = addon.setUpContentFrame(titleFrame)
-    --contentFrame:Hide()
+    contentFrame:Hide()
     
     searchBox:SetScript("OnTextChanged", function(self)
         local query = self:GetText()
         setLocationButtons(query)
-        if query == "" and query == nil then
+        if query == "" or query == nil then
             contentFrame:Hide()
         else
             contentFrame:Show()

--- a/JackJack.lua
+++ b/JackJack.lua
@@ -271,7 +271,7 @@ local function setUpFrame()
 
     -- add a scroll frame which will contain location buttons
     local scrollFrame = CreateFrame("ScrollFrame", "JackJackScrollFrame", frame, "UIPanelScrollFrameTemplate")
-    scrollFrame:SetPoint("TOPLEFT", frame, "TOPLEFT", JJ_MARGIN, JJ_MARGIN)
+    scrollFrame:SetPoint("TOPLEFT", frame, "TOPLEFT", JJ_MARGIN, -JJ_MARGIN)
     scrollFrame:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -JJ_SCROLLBAR_REGION_WIDTH, JJ_MARGIN)
 
     local scrollChild = CreateFrame("Frame")

--- a/JackJack.lua
+++ b/JackJack.lua
@@ -4,6 +4,7 @@ local addonName, addon = ...
 -- slash commands
 SLASH_JACKJACK1 = "/jackjack"
 SLASH_JACKJACK2 = "/jj"
+SLASH_JJRESET1 = "/jjreset"
 
 -- sizing for frames
 -- TODO: these are temporary until I move all the UI code to JackJackUI.lua
@@ -247,7 +248,7 @@ end
 -- @return searchBox            EditBox frame for the search box
 -- @return searchResultsText    FontString showing number of search resutls
 local function setUpFrame()
-    local titleFrame, searchBox = addon.setUpTitleFrame()
+    local titleFrame, searchBox, searchResultsText = addon.setUpTitleFrame()
     
     local contentFrame = addon.setUpContentFrame(titleFrame)
     contentFrame:Hide()
@@ -257,17 +258,13 @@ local function setUpFrame()
         setLocationButtons(query)
         if query == "" or query == nil then
             contentFrame:Hide()
+            searchResultsText:SetText('Search for a WoW location (e.g. "Orgrimmar")')
         else
             contentFrame:Show()
         end
     end)
 
     local frame = contentFrame -- TODO: just replace all the frame references with this one
-
-    -- add text below search box that shows the number of locations found
-    local searchResultsText = searchBox:CreateFontString(nil, "OVERLAY", "GameFontNormal")
-    searchResultsText:SetPoint("BOTTOMLEFT", searchBox, "BOTTOMLEFT", 0, -2 * JJ_MARGIN)
-    searchResultsText:SetText("No possible matching locations found!")
 
     -- add a scroll frame which will contain location buttons
     local scrollFrame = CreateFrame("ScrollFrame", "JackJackScrollFrame", frame, "UIPanelScrollFrameTemplate")
@@ -279,7 +276,7 @@ local function setUpFrame()
     scrollChild:SetWidth(1) -- not sure if setting this to 1 has any effect vs setting it to the parent's width
     scrollChild:SetHeight(1) -- this can be any value, it doesn't matter
 
-    return frame, scrollChild, searchBox, searchResultsText
+    return titleFrame, scrollChild, searchBox, searchResultsText
 end
 
 --- Sets up the location tooltip frame
@@ -288,7 +285,7 @@ local function setUpLocationTooltip()
     return tooltip
 end
 
-JJ_WINDOW, JJ_LOCATION_BUTTON_CONTAINER, JJ_SEARCH_BOX, JJ_SEARCH_RESULTS_TXT = setUpFrame()
+JJ_TITLE, JJ_LOCATION_BUTTON_CONTAINER, JJ_SEARCH_BOX, JJ_SEARCH_RESULTS_TXT = setUpFrame()
 JJ_LOCATION_BUTTON_GROUPS = {} -- contains {["location"]=Button, ["directions"]=Button} for each button group
 JJ_TOOLTIP = setUpLocationTooltip()
 JJ_DIRECTIONS_WAYPOINTS = {}
@@ -297,6 +294,11 @@ SlashCmdList["JACKJACK"] = function(msg, editBox)
     local locationName = msg
     setLocationButtons(locationName)
     JJ_SEARCH_BOX:SetText(locationName)
-    JJ_WINDOW:Show()
+    JJ_TITLE:Show()
     WorldMapFrame:Show()
+end
+
+SlashCmdList["JJRESET"] = function(msg, editBox)
+    JJ_TITLE:ClearAllPoints()
+    JJ_TITLE:SetPoint("TOPLEFT", WorldMapFrame, "TOPRIGHT", 0, 0)
 end

--- a/JackJack.lua
+++ b/JackJack.lua
@@ -249,56 +249,22 @@ end
 -- @return searchBox            EditBox frame for the search box
 -- @return searchResultsText    FontString showing number of search resutls
 local function setUpFrame()
-    -- create the window
-    local frame = CreateFrame("Frame", "JackJackFrame", WorldMapFrame, "BackdropTemplate")
-    frame:SetSize(JJ_WIDTH, JJ_HEIGHT)
-    if not frame:IsUserPlaced() then
-        frame:SetPoint("TOPLEFT", WorldMapFrame, "TOPRIGHT", 0, 0)
-    end
-    frame:SetFrameStrata("DIALOG")
-    frame:SetFrameLevel(1)
-    frame:Hide()
-
-    frame:SetBackdrop({
-        bgFile = "Interface\\DialogFrame\\UI-DialogBox-Background",
-        edgeFile = "Interface\\DialogFrame\\UI-DialogBox-Border",
-        tile = true,
-        tileEdge = true,
-        tileSize = 8,
-        edgeSize = 8,
-        insets = { left = 1, right = 1, top = 1, bottom = 1 },
-    })
-
-    -- make it movable
-    frame:SetMovable(true)
-    frame:EnableMouse(true)
-    frame:RegisterForDrag("LeftButton")
-    frame:SetScript("OnDragStart", frame.StartMoving)
-    frame:SetScript("OnDragStop", frame.StopMovingOrSizing)
-
-    -- add title bar
-    local titleBar = frame:CreateTexture(nil, "ARTWORK")
-    titleBar:SetTexture("Interface\\DialogFrame\\UI-DialogBox-Header")
-    titleBar:SetPoint("CENTER", frame, "TOP", 0, -JJ_TITLEBAR_HEIGHT / 4)
-    titleBar:SetSize(256, JJ_TITLEBAR_HEIGHT)
-
-    -- add text to title bar
-    local titleText = frame:CreateFontString(nil, "ARTWORK", "GameFontNormal")
-    titleText:SetPoint("CENTER", frame, "TOP", 0, -4)
-    titleText:SetText("JackJack")
-
-    -- extend drag area to include title bar
-    frame:SetHitRectInsets(0, 0, -JJ_TITLEBAR_HEIGHT / 2, 0)
-
-    -- add a search box
-    local searchBox = CreateFrame("EditBox", "JackJackSearchBox", frame, "InputBoxTemplate")
-    searchBox:SetFontObject("GameFontNormalLarge")
-    searchBox:SetSize(JJ_SEARCH_WIDTH, JJ_SEARCH_HEIGHT)
-    searchBox:SetPoint("TOP", frame, "TOP", 0, (-JJ_TITLEBAR_HEIGHT / 4) - JJ_MARGIN)
-    searchBox:SetAutoFocus(false)
+    local titleFrame, searchBox = addon.setUpTitleFrame()
+    
+    local contentFrame = addon.setUpContentFrame(titleFrame)
+    --contentFrame:Hide()
+    
     searchBox:SetScript("OnTextChanged", function(self)
-        setLocationButtons(self:GetText())
+        local query = self:GetText()
+        setLocationButtons(query)
+        if query == "" and query == nil then
+            contentFrame:Hide()
+        else
+            contentFrame:Show()
+        end
     end)
+
+    local frame = contentFrame -- TODO: just replace all the frame references with this one
 
     -- add text below search box that shows the number of locations found
     local searchResultsText = searchBox:CreateFontString(nil, "OVERLAY", "GameFontNormal")
@@ -307,7 +273,7 @@ local function setUpFrame()
 
     -- add a scroll frame which will contain location buttons
     local scrollFrame = CreateFrame("ScrollFrame", "JackJackScrollFrame", frame, "UIPanelScrollFrameTemplate")
-    scrollFrame:SetPoint("TOPLEFT", frame, "TOPLEFT", JJ_MARGIN, -6 * JJ_MARGIN - JJ_SEARCH_HEIGHT)
+    scrollFrame:SetPoint("TOPLEFT", frame, "TOPLEFT", JJ_MARGIN, JJ_MARGIN)
     scrollFrame:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -JJ_SCROLLBAR_REGION_WIDTH, JJ_MARGIN)
 
     local scrollChild = CreateFrame("Frame")
@@ -315,7 +281,6 @@ local function setUpFrame()
     scrollChild:SetWidth(1) -- not sure if setting this to 1 has any effect vs setting it to the parent's width
     scrollChild:SetHeight(1) -- this can be any value, it doesn't matter
 
-    frame:Show()
     return frame, scrollChild, searchBox, searchResultsText
 end
 

--- a/JackJack.lua
+++ b/JackJack.lua
@@ -6,16 +6,14 @@ SLASH_JACKJACK1 = "/jackjack"
 SLASH_JACKJACK2 = "/jj"
 
 -- sizing for frames
-JJ_WIDTH = 350
-JJ_HEIGHT = 500
-JJ_MARGIN = 8
-JJ_SCROLLBAR_REGION_WIDTH = 30 -- not the actual width of the scrollbar, just the region the scrollbar is in
-JJ_DIRECTIONS_BUTTON_WIDTH = 40
-JJ_BUTTON_WIDTH = JJ_WIDTH - JJ_SCROLLBAR_REGION_WIDTH - JJ_MARGIN - JJ_DIRECTIONS_BUTTON_WIDTH
-JJ_BUTTON_HEIGHT = 40
-JJ_SEARCH_HEIGHT = 25
-JJ_SEARCH_WIDTH = JJ_WIDTH - (3 * JJ_MARGIN)
-JJ_TITLEBAR_HEIGHT = 64
+-- TODO: these are temporary until I move all the UI code to JackJackUI.lua
+JJ_WIDTH = addon.UI_CONSTS.WIDTH
+JJ_HEIGHT = addon.UI_CONSTS.CONTENT_HEIGHT
+JJ_MARGIN = addon.UI_CONSTS.MARGIN
+JJ_SCROLLBAR_REGION_WIDTH = addon.UI_CONSTS.SCROLLBAR_REGION_WIDTH
+JJ_DIRECTIONS_BUTTON_WIDTH = addon.UI_CONSTS.DIRECTIONS_BUTTON_WIDTH
+JJ_BUTTON_WIDTH = addon.UI_CONSTS.BUTTON_WIDTH
+JJ_BUTTON_HEIGHT = addon.UI_CONSTS.BUTTON_HEIGHT
 
 --- Set the text that displays the number of search results accordingly
 -- @param numResults the number of search results

--- a/JackJack.toc
+++ b/JackJack.toc
@@ -12,4 +12,5 @@ WaypointNodeWithLocation.lua
 WaypointEdgeReduced.lua
 PlayerConditionExpanded.lua
 JackJackDirections.lua
+JackJackUI.lua
 JackJack.lua

--- a/JackJackUI.lua
+++ b/JackJackUI.lua
@@ -1,0 +1,95 @@
+local addonName, addon = ...
+
+addon.UI_CONSTS = {
+    ["WIDTH"] = 350,
+    ["TITLE_FRAME_HEIGHT"] = 100,
+    ["CONTENT_HEIGHT"] = 500,
+    ["MARGIN"] = 8,
+    ["SCROLLBAR_REGION_WIDTH"] = 30, -- not the actual width of the scrollbar, just the region the scrollbar is in
+    ["DIRECTIONS_BUTTON_WIDTH"] = 40,
+    ["BUTTON_HEIGHT"] = 40,
+    ["SEARCH_HEIGHT"] = 25,
+    ["TITLEBAR_HEIGHT"] = 64,
+}
+addon.UI_CONSTS["BUTTON_WIDTH"] = addon.UI_CONSTS.WIDTH -
+    addon.UI_CONSTS.SCROLLBAR_REGION_WIDTH -
+    addon.UI_CONSTS.MARGIN -
+    addon.UI_CONSTS.DIRECTIONS_BUTTON_WIDTH
+addon.UI_CONSTS["SEARCH_WIDTH"] = addon.UI_CONSTS.WIDTH - (3 * addon.UI_CONSTS.MARGIN)
+
+--- Sets up the title frame that's always visible when the map is open
+-- @return frame            UI frame for the title
+-- @return searchBox        UI frame for the search box in the title frame
+addon.setUpTitleFrame = function ()
+    local frame = CreateFrame("Frame", "JackJackTitle", WorldMapFrame, "BackdropTemplate")
+    frame:SetSize(addon.UI_CONSTS.WIDTH, addon.UI_CONSTS.TITLE_FRAME_HEIGHT)
+    if not frame:IsUserPlaced() then
+        frame:SetPoint("TOPLEFT", WorldMapFrame, "TOPLEFT", 0, 0)
+    end
+    frame:SetFrameStrata("DIALOG")
+    frame:SetFrameLevel(1)
+    --frame:Hide() -- TODO: do we need this or not
+
+    frame:SetBackdrop({
+        bgFile = "Interface\\DialogFrame\\UI-DialogBox-Background",
+        edgeFile = "Interface\\DialogFrame\\UI-DialogBox-Border",
+        tile = true,
+        tileEdge = true,
+        tileSize = 8,
+        edgeSize = 8,
+        insets = { left = 1, right = 1, top = 1, bottom = 1 }
+    })
+
+    -- make it movable
+    frame:SetMovable(true)
+    frame:EnableMouse(true)
+    frame:RegisterForDrag("LeftButton")
+    frame:SetScript("OnDragStart", frame.StartMoving)
+    frame:SetScript("OnDragStop", frame.StopMovingOrSizing)
+
+    -- add title bar (the very top, and actually contains the title string)
+    local titleBar = frame:CreateTexture(nil, "ARTWORK")
+    titleBar:SetTexture("Interface\\DialogFrame\\UI-DialogBox-Header")
+    titleBar:SetPoint("CENTER", frame, "TOP", 0, -addon.UI_CONSTS.TITLEBAR_HEIGHT / 4)
+    titleBar:SetSize(256, addon.UI_CONSTS.TITLEBAR_HEIGHT)
+
+    -- add text to title bar
+    local titleText = frame:CreateFontString(nil, "ARTWORK", "GameFontNormal")
+    titleText:SetPoint("CENTER", frame, "TOP", 0, -4)
+    titleText:SetText("JackJack")
+
+    -- extend drag area to include title bar
+    frame:SetHitRectInsets(0, 0, -addon.UI_CONSTS.TITLEBAR_HEIGHT / 2, 0)
+
+    -- add a search box
+    local searchBox = CreateFrame("EditBox", "JackJackSearchBox", frame, "InputBoxTemplate")
+    searchBox:SetFontObject("GameFontNormalLarge")
+    searchBox:SetSize(addon.UI_CONSTS.SEARCH_WIDTH, addon.UI_CONSTS.SEARCH_HEIGHT)
+    searchBox:SetPoint("TOP", frame, "TOP", 0, (-addon.UI_CONSTS.TITLEBAR_HEIGHT / 4) - addon.UI_CONSTS.MARGIN)
+    searchBox:SetAutoFocus(false)
+    searchBox:SetScript("OnTextChanged", onSearchCallback)
+
+    return frame, searchBox
+end
+
+--- Set up the content frame that's only visible when there's a search
+-- @param uiParent  The parent frame for the content frame
+addon.setUpContentFrame = function(uiParent)
+    local frame = CreateFrame("Frame", "JackJackContents", uiParent, "BackdropTemplate")
+    frame:SetSize(addon.UI_CONSTS.WIDTH, addon.UI_CONSTS.CONTENT_HEIGHT)
+    frame:SetPoint("TOPLEFT", uiParent, "BOTTOMLEFT", 0, 0)
+    frame:SetFrameStrata("DIALOG")
+    frame:SetFrameLevel(1)
+
+    frame:SetBackdrop({
+        bgFile = "Interface\\DialogFrame\\UI-DialogBox-Background",
+        edgeFile = "Interface\\DialogFrame\\UI-DialogBox-Border",
+        tile = true,
+        tileEdge = true,
+        tileSize = 8,
+        edgeSize = 8,
+        insets = { left = 1, right = 1, top = 1, bottom = 1 }
+    })
+
+    return frame
+end

--- a/JackJackUI.lua
+++ b/JackJackUI.lua
@@ -18,13 +18,14 @@ addon.UI_CONSTS["BUTTON_WIDTH"] = addon.UI_CONSTS.WIDTH -
 addon.UI_CONSTS["SEARCH_WIDTH"] = addon.UI_CONSTS.WIDTH - (3 * addon.UI_CONSTS.MARGIN)
 
 --- Sets up the title frame that's always visible when the map is open
--- @return frame            UI frame for the title
--- @return searchBox        UI frame for the search box in the title frame
+-- @return frame                UI frame for the title
+-- @return searchBox            UI frame for the search box in the title frame
+-- @return searchResultsText    FontString for number of search results
 addon.setUpTitleFrame = function ()
     local frame = CreateFrame("Frame", "JackJackTitle", WorldMapFrame, "BackdropTemplate")
     frame:SetSize(addon.UI_CONSTS.WIDTH, addon.UI_CONSTS.TITLE_FRAME_HEIGHT)
     if not frame:IsUserPlaced() then
-        frame:SetPoint("TOPLEFT", WorldMapFrame, "TOPLEFT", 0, 0)
+        frame:SetPoint("TOPLEFT", WorldMapFrame, "TOPRIGHT", 0, 0)
     end
     frame:SetFrameStrata("DIALOG")
     frame:SetFrameLevel(1)
@@ -69,7 +70,12 @@ addon.setUpTitleFrame = function ()
     searchBox:SetAutoFocus(false)
     searchBox:SetScript("OnTextChanged", onSearchCallback)
 
-    return frame, searchBox
+    -- add text below search box that shows the number of locations found
+    local searchResultsText = searchBox:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    searchResultsText:SetPoint("BOTTOMLEFT", searchBox, "BOTTOMLEFT", 0, -2 * addon.UI_CONSTS.MARGIN)
+    searchResultsText:SetText("No possible matching locations found!")
+
+    return frame, searchBox, searchResultsText
 end
 
 --- Set up the content frame that's only visible when there's a search

--- a/JackJackUI.lua
+++ b/JackJackUI.lua
@@ -2,7 +2,7 @@ local addonName, addon = ...
 
 addon.UI_CONSTS = {
     ["WIDTH"] = 350,
-    ["TITLE_FRAME_HEIGHT"] = 100,
+    ["TITLE_FRAME_HEIGHT"] = 75,
     ["CONTENT_HEIGHT"] = 500,
     ["MARGIN"] = 8,
     ["SCROLLBAR_REGION_WIDTH"] = 30, -- not the actual width of the scrollbar, just the region the scrollbar is in


### PR DESCRIPTION
Splits the JJ window into two frames: a "title" frame containing the title and searchbar, and a "content" frame with buttons for the search results. When there is a searchbar contains text, the content frame is shown and vice versa. See #28.